### PR TITLE
Bug Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ nosetests.xml
 .idea
 *.sublime-project
 *.sublime-workspace
+*.vscode
 
 # For Ipam
 fabfile.py

--- a/openipam/dns/forms.py
+++ b/openipam/dns/forms.py
@@ -113,7 +113,7 @@ class DNSUpdateForm(forms.ModelForm):
         fields = ("name", "ttl", "text_content")
 
 
-class DSNCreateFrom(forms.Form):
+class DNSCreateForm(forms.Form):
     name = forms.CharField(required=True)
     dns_type = forms.ModelChoiceField(
         queryset=DnsType.objects.all(), required=True, widget=Select2Widget
@@ -122,7 +122,7 @@ class DSNCreateFrom(forms.Form):
     content = forms.CharField(required=True)
 
     def __init__(self, user, *args, **kwargs):
-        super(DSNCreateFrom, self).__init__(*args, **kwargs)
+        super(DNSCreateForm, self).__init__(*args, **kwargs)
 
         self.fields["dns_type"].queryset = get_objects_for_user(
             user,

--- a/openipam/dns/managers.py
+++ b/openipam/dns/managers.py
@@ -208,6 +208,9 @@ class DnsManager(Manager):
             if dns_type:
                 dns_record.dns_type = dns_type
 
+            # strip trailing dots
+            content = content.rstrip(".")
+
             if not content:
                 raise ValidationError("Content is required to create a DNS record.")
 

--- a/openipam/dns/models.py
+++ b/openipam/dns/models.py
@@ -314,6 +314,9 @@ class DnsRecord(models.Model):
         # TODO: more of these need to be added
         try:
             if self.text_content:
+                # Strip off any trailing dots
+                self.text_content = self.text_content.rstrip(".")
+
                 if self.dns_type.name == "CNAME" and len(self.text_content) > 255:
                     raise ValidationError("CNAME Content cannot be longer than 255.")
 

--- a/openipam/dns/models.py
+++ b/openipam/dns/models.py
@@ -83,7 +83,7 @@ class DnsRecord(models.Model):
         max_length=255,
         error_messages={"blank": "Name fields for DNS records cannot be blank."},
     )
-    text_content = models.CharField(max_length=255, blank=True, null=True)
+    text_content = models.CharField(max_length=65535, blank=True, null=True)
     ip_content = models.ForeignKey(
         "network.Address",
         db_column="ip_content",
@@ -314,6 +314,9 @@ class DnsRecord(models.Model):
         # TODO: more of these need to be added
         try:
             if self.text_content:
+                if self.dns_type.name == "CNAME" and len(self.text_content) > 255:
+                    raise ValidationError("CNAME Content cannot be longer than 255.")
+
                 if self.dns_type.name in ["NS", "CNAME", "PTR", "MX"]:
                     validate_fqdn(self.text_content)
 

--- a/openipam/dns/views.py
+++ b/openipam/dns/views.py
@@ -457,7 +457,7 @@ class DNSListView(PermissionRequiredMixin, TemplateView):
                 messages.success(
                     self.request, "Selected DNS records have been updated."
                 )
-                return redirect("list_dns")
+                return redirect("dns:list")
 
         return self.get(request, *args, **kwargs)
 

--- a/openipam/dns/views.py
+++ b/openipam/dns/views.py
@@ -14,7 +14,7 @@ from django.forms.utils import ErrorList
 from django.db import transaction
 from django.shortcuts import get_object_or_404
 
-from openipam.dns.forms import DSNCreateFrom
+from openipam.dns.forms import DNSCreateForm
 from openipam.dns.models import DnsRecord, DnsType
 from openipam.dns.actions import delete_records
 from openipam.core.views import BaseDatatableView
@@ -465,7 +465,7 @@ class DNSListView(PermissionRequiredMixin, TemplateView):
 class DNSCreateUpdateView(PermissionRequiredMixin, FormView):
     permission_required = "dns.add_dnsrecord"
     template_name = "dns/dnsrecord_form.html"
-    form_class = DSNCreateFrom
+    form_class = DNSCreateForm
     success_url = reverse_lazy("dns:list")
     record = None
 


### PR DESCRIPTION
Allow content for DNS record to be 65535 max-length, except CNAME (still 255). Strip off trailing dots on every content before running through validations.