### PR TITLE
Report hosts that have an "expose_" prefix as the value of their nac-profile attribute

### DIFF
--- a/openipam/api/views/report.py
+++ b/openipam/api/views/report.py
@@ -24,7 +24,7 @@ from openipam.report.models import Ports
 from openipam.report.models import database_connect, database_close
 from openipam.network.models import Network, Lease, Address
 from openipam.dns.models import DnsRecord
-from openipam.conf.ipam_settings import CONFIG
+from openipam.conf.ipam_settings import CONFIG, CONFIG_DEFAULTS
 from openipam.conf.settings import get_buildingmap_data
 
 from functools import reduce
@@ -436,8 +436,10 @@ class ServerHostView(APIView):
 
     def get(self, request, format=None, **kwargs):
         hosts = Host.objects.prefetch_related("addresses").filter(
-            structured_attributes__structured_attribute_value__attribute__name="border-profile",
-            structured_attributes__structured_attribute_value__value="server",
+            structured_attributes__structured_attribute_value__attribute__name="nac-profile",
+            structured_attributes__structured_attribute_value__value__startswith=CONFIG_DEFAULTS[
+                "NAC_PROFILE_IS_SERVER_PREFIX"
+            ],
         )
 
         user_perms_prefetch = UserObjectPermission.objects.select_related(

--- a/openipam/conf/ipam_settings.py
+++ b/openipam/conf/ipam_settings.py
@@ -33,6 +33,7 @@ CONFIG_DEFAULTS = {
     "DUO_LOGIN": False,
     "DUO_SETTINGS": {"IKEY": "", "SKEY": "", "AKEY": "", "HOST": ""},
     "WEATHERMAP_DATA": {"data": {}, "config": {}},
+    "NAC_PROFILE_IS_SERVER_PREFIX": "expose_",
 }
 
 USER_CONFIG = getattr(settings, "OPENIPAM", {})

--- a/openipam/report/templates/report/server_hosts.html
+++ b/openipam/report/templates/report/server_hosts.html
@@ -54,7 +54,7 @@
 			Download Report (CSV)
 		</a>
 	</div>
-	<p>Hosts that have 'server-profile' attribute set.</p>
+	<p>Hosts whose nac-profile starts with "expose_".</p>
 	<table id="result_list" class="table table-striped table-condensed table-bordered">
 		<tr>
 			<thead>


### PR DESCRIPTION
Relevant fun postgres query is fun:
```sql
select hosts.* from hosts join structured_attributes_to_hosts on structured_attributes_to_hosts.mac=hosts.mac join structured_attribute_values on structured_attributes_to_hosts.avid=structured_attribute_values.id join attributes on structured_attribute_values.aid=attributes.id where attributes.name='nac-profile' and starts_with(structured_attribute_values.value, 'expose_') order by hosts.hostname;
```