### PR TITLE
Add API endpoint to query gul by mac and by address

### DIFF
--- a/openipam/api/filters/hosts.py
+++ b/openipam/api/filters/hosts.py
@@ -4,9 +4,14 @@ from django.contrib.auth import get_user_model
 from django.db.models import Q
 from django.core.exceptions import ValidationError
 
-from openipam.hosts.models import Host
+from openipam.hosts.models import GulRecentArpByaddress, GulRecentArpBymac, Host
 
-from django_filters import FilterSet, CharFilter, NumberFilter
+from django_filters import (
+    FilterSet,
+    CharFilter,
+    NumberFilter,
+    IsoDateTimeFromToRangeFilter,
+)
 
 import re
 
@@ -151,3 +156,21 @@ class HostFilter(FilterSet):
         model = Host
         # TODO: This is dumb, django-filter 0.14 needs docs and bug fixes
         fields = ["hostname"]
+
+
+class RecentGulFilter(FilterSet):
+    mac = CharFilter(field_name="host__mac")
+    address = CharFilter()
+    stopstamp = IsoDateTimeFromToRangeFilter()
+
+
+class RecentGulArpByAddressFilter(RecentGulFilter):
+    class Meta:
+        model = GulRecentArpByaddress
+        fields = ("mac", "address", "stopstamp")
+
+
+class RecentGulArpByMacFilter(RecentGulFilter):
+    class Meta:
+        model = GulRecentArpBymac
+        fields = ("mac", "address", "stopstamp")

--- a/openipam/api/serializers/hosts.py
+++ b/openipam/api/serializers/hosts.py
@@ -9,7 +9,14 @@ from django.contrib.contenttypes.models import ContentType
 
 from rest_framework import serializers
 
-from openipam.hosts.models import Host, Attribute, StructuredAttributeValue, Disabled
+from openipam.hosts.models import (
+    GulRecentArpByaddress,
+    GulRecentArpBymac,
+    Host,
+    Attribute,
+    StructuredAttributeValue,
+    Disabled,
+)
 from openipam.network.models import Network, Address, Pool, DhcpGroup
 from openipam.api.serializers.base import (
     MACAddressField,
@@ -609,3 +616,25 @@ class DisabledHostDeleteSerializer(serializers.ModelSerializer):
     class Meta:
         model = Disabled
         fields = ("mac",)
+
+
+class RecentGulEntriesSerializer(serializers.ModelSerializer):
+    mac = serializers.SerializerMethodField()
+    address = serializers.IPAddressField()
+    stopstamp = serializers.DateTimeField()
+
+    def get_mac(self, obj):
+        if hasattr(obj, "host"):
+            return str(obj.host.mac)
+
+
+class RecentGulMacEntriesSerializer(RecentGulEntriesSerializer):
+    class Meta:
+        model = GulRecentArpBymac
+        fields = ("mac", "address", "stopstamp")
+
+
+class RecentGulAddressEntriesSerializer(RecentGulEntriesSerializer):
+    class Meta:
+        model = GulRecentArpByaddress
+        fields = ("mac", "address", "stopstamp")

--- a/openipam/api/urls.py
+++ b/openipam/api/urls.py
@@ -297,6 +297,14 @@ urlpatterns = [
         r"^address(es)?/$", views.network.AddressList.as_view(), name="api_address_list"
     ),
     url(
+        r"^addresses/recent/$",
+        views.hosts.RecentGulAddressEntries.as_view(),
+        name="api_gul_addresses",
+    ),
+    url(
+        r"^mac/recent/$", views.hosts.RecentGulMacEntries.as_view(), name="api_gul_macs"
+    ),
+    url(
         r"^login/has_auth/", views.base.UserAuthenticated.as_view(), name="api_has_auth"
     ),
     url(r"^login/jwt_token/", views.base.obtain_jwt_token),

--- a/openipam/api/views/hosts.py
+++ b/openipam/api/views/hosts.py
@@ -1,3 +1,4 @@
+from datetime import timezone
 from django.shortcuts import get_object_or_404
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
@@ -16,6 +17,8 @@ from rest_framework.renderers import BrowsableAPIRenderer, JSONRenderer
 from rest_framework_csv.renderers import CSVRenderer
 
 from openipam.hosts.models import (
+    GulRecentArpByaddress,
+    GulRecentArpBymac,
     Host,
     StructuredAttributeToHost,
     FreeformAttributeToHost,
@@ -26,8 +29,17 @@ from openipam.hosts.models import (
 from openipam.network.models import Lease
 from openipam.api.views.base import APIPagination, APIMaxPagination
 from openipam.api.serializers import hosts as host_serializers
-from openipam.api.filters.hosts import HostFilter
-from openipam.api.permissions import IPAMChangeHostPermission, IPAMAPIAdminPermission
+from openipam.api.filters.hosts import (
+    HostFilter,
+    RecentGulArpByAddressFilter,
+    RecentGulArpByMacFilter,
+    RecentGulFilter,
+)
+from openipam.api.permissions import (
+    IPAMAPIPermission,
+    IPAMChangeHostPermission,
+    IPAMAPIAdminPermission,
+)
 
 from guardian.shortcuts import assign_perm, remove_perm
 
@@ -572,3 +584,21 @@ class DisabledHostDelete(generics.DestroyAPIView):
 
     def post(self, request, *args, **kwargs):
         return self.destroy(request, *args, **kwargs)
+
+
+class RecentGulMacEntries(generics.ListAPIView):
+    permission_classes = (IsAuthenticated, IPAMAPIPermission)
+    serializer_class = host_serializers.RecentGulMacEntriesSerializer
+    queryset = GulRecentArpBymac.objects.all()
+
+    filter_backends = (DjangoFilterBackend,)
+    filter_class = RecentGulArpByMacFilter
+
+
+class RecentGulAddressEntries(generics.ListAPIView):
+    permission_classes = (IsAuthenticated, IPAMAPIPermission)
+    serializer_class = host_serializers.RecentGulAddressEntriesSerializer
+    queryset = GulRecentArpByaddress.objects.all()
+
+    filter_backends = (DjangoFilterBackend,)
+    filter_class = RecentGulArpByAddressFilter

--- a/openipam/api/views/hosts.py
+++ b/openipam/api/views/hosts.py
@@ -1,4 +1,3 @@
-from datetime import timezone
 from django.shortcuts import get_object_or_404
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
@@ -33,7 +32,6 @@ from openipam.api.filters.hosts import (
     HostFilter,
     RecentGulArpByAddressFilter,
     RecentGulArpByMacFilter,
-    RecentGulFilter,
 )
 from openipam.api.permissions import (
     IPAMAPIPermission,


### PR DESCRIPTION
Added two endpoints:
1. `/api/addresses/recent/`
2. `/api/mac/recent/`

Which can each be filtered via the following GET params:
* `mac`
* `address`
* `stopstamp`
* `stopstamp_before`
* `stopstamp_after`

For example:
```javascript
fetch('/api/addresses/recent?stopstamp_after=2022-10-10T00:00:00Z')
.then((r) => r.json())
.then((j) => console.log(j));
```