### PR TITLE
Add bulk DNS record repopulation routes on hosts, and report to do so. 

### DIFF
--- a/openipam/api/urls.py
+++ b/openipam/api/urls.py
@@ -202,9 +202,14 @@ urlpatterns = [
         name="api_host_delete",
     ),
     url(
-        "hosts/bulk_delete/",
+        r"^hosts/bulk_delete/$",
         views.hosts.HostBulkDelete.as_view(),
         name="api_host_bulk_delete",
+    ),
+    url(
+        r"^hosts/bulk_repopulate_dns/$",
+        views.hosts.BulkFixHostDNSRecords.as_view(),
+        name="api_bulk_repopulate_host_dns_records",
     ),
     url(
         r"^hosts?/(?P<pk>([0-9a-fA-F]{2}[:-]?){5}[0-9a-fA-F]{2})/$",

--- a/openipam/api/views/hosts.py
+++ b/openipam/api/views/hosts.py
@@ -14,8 +14,6 @@ from rest_framework import status
 from rest_framework.renderers import BrowsableAPIRenderer, JSONRenderer
 
 from rest_framework_csv.renderers import CSVRenderer
-from openipam.dns.models import DnsType
-from openipam.hosts.actions import populate_primary_dns
 
 from openipam.hosts.models import (
     GulRecentArpByaddress,

--- a/openipam/api/views/hosts.py
+++ b/openipam/api/views/hosts.py
@@ -14,6 +14,8 @@ from rest_framework import status
 from rest_framework.renderers import BrowsableAPIRenderer, JSONRenderer
 
 from rest_framework_csv.renderers import CSVRenderer
+from openipam.dns.models import DnsType
+from openipam.hosts.actions import populate_primary_dns
 
 from openipam.hosts.models import (
     Host,
@@ -284,9 +286,11 @@ class HostBulkDelete(APIView):
     permission_classes = (IsAuthenticated, IPAMAPIAdminPermission)
 
     def post(self, request):
-        if "mac_addr[]" not in request.data:
+        if "mac_addr[]" not in request.data or not len(
+            list(filter(lambda x: x, request.data.getlist("mac_addr[]")))
+        ):
             return Response(
-                "No host mac addresses(es) specified",
+                {"error": "No host mac addresses(es) specified"},
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
@@ -294,7 +298,51 @@ class HostBulkDelete(APIView):
             request.user
         )
 
-        return Response(status=status.HTTP_200_OK)
+        return Response({"success": True}, status=status.HTTP_200_OK)
+
+
+class BulkFixHostDNSRecords(APIView):
+    """
+    Attempts to re-populate a list of hosts' DNS records from their mac addresses (mac_addr[])
+    """
+
+    permission_classes = (IsAuthenticated, IPAMAPIAdminPermission)
+
+    def post(self, request):
+        if "mac_addr[]" not in request.data or not len(
+            list(filter(lambda x: x, request.data.getlist("mac_addr[]")))
+        ):
+            return Response(
+                {"error": "Must specify mac addresses of hosts to populate"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        hosts = Host.objects.filter(
+            pk__in=request.data.getlist("mac_addr[]"),
+            dns_records__isnull=True,
+        )
+
+        populate_record_status = []
+        for host in hosts:
+            try:
+                dns_records = host.get_dns_records()
+                if dns_records:
+                    for record in dns_records:
+                        record.host = host
+                        record.changed_by = request.user
+                        record.save()
+                    continue
+
+                host.delete_dns_records(user=request.user)
+                host.add_dns_records(user=request.user)
+
+                populate_record_status.append({"mac": str(host.mac), "success": True})
+            except Exception as e:
+                populate_record_status.append(
+                    {"mac": str(host.mac), "success": False, "error": e}
+                )
+
+        return Response(populate_record_status, status=status.HTTP_200_OK)
 
 
 class HostOwnerList(generics.RetrieveAPIView):

--- a/openipam/report/static/report/js/host/confirm_modal.js
+++ b/openipam/report/static/report/js/host/confirm_modal.js
@@ -1,0 +1,89 @@
+/**
+ * Asynchronous function to return an { error? } when modal is confirmed
+ * @callback onSubmitCallback
+ * @return Promise<Object | null>
+ */
+
+/**
+ * Function called when onSubmit contains no error
+ * @callback onSuccessCallback
+ */
+
+/**
+ * @param {string} confirmationTitle 
+ * @param {string} confirmationMessage
+ * @param {onSubmitCallback} onSubmit 
+ * @param {onSuccessCallback} onSuccess
+ */
+$.fn.confirmHostsModal = function (confirmationTitle, confirmationMessage, onSubmit, onSuccess) {
+  const render = (error) => {
+    this.html(`
+        <div class="modal-dialog">
+          <div class="modal-content">
+            <div class="modal-header">
+              <button
+                type="button"
+                class="close"
+                data-dismiss="modal"
+                aria-hidden="true"
+              >
+                &times;
+              </button>
+              <h3 class="modal-title">
+                <span class="oaction"></span>
+                ${confirmationTitle}
+              </h3>
+            </div>
+            <div class="modal-body">
+              <div class="clear">
+                <p>
+                  ${confirmationMessage}
+                </p>
+                ${error ? `
+                  <div class="alert alert-danger" role="alert" id="error">
+                    <span
+                      class="glyphicon glyphicon-exclamation-sign"
+                      aria-hidden="true"
+                    ></span>
+                    <span class="sr-only"></span>
+                    Error: ${error}
+                  </div>
+                ` : ''}
+              </div>
+            </div>
+            <div class="modal-footer">
+              <button class="btn btn-danger ${error ? 'disabled' : ''}" id="confirm-modal-submit">Yes</button>
+              <button
+                class="btn btn-default"
+                data-dismiss="modal"
+                aria-hidden="true"
+                id="cancel-delete"
+              >
+                No
+              </button>
+            </div>
+          </div>
+        </div>
+      `);
+    this.modal();
+  }
+
+  $("#error").hide();
+  $("#confirm-modal-submit").removeClass("disabled");
+  render();
+
+  $("#confirm-modal-submit").on("click", async function () {
+    $("#error").hide();
+    $(this).addClass("disabled");
+
+    const result = await onSubmit().catch((err) => err.responseJSON);
+
+    if (!result) {
+      render("Submission failed.");
+    } else if (result.error) {
+      render(result.error);
+    } else {
+      onSuccess();
+    }
+  });
+}

--- a/openipam/report/static/report/js/host/multiselect_host_form.js
+++ b/openipam/report/static/report/js/host/multiselect_host_form.js
@@ -1,0 +1,39 @@
+const toggleAllCheckboxes = (check = true) =>
+  $("input[type=checkbox]").each(function () {
+    $(this).prop("checked", check);
+  });
+
+const macCount = (form) => $(form)
+  .serializeArray()
+  .filter((input) => input.name === "mac_addr[]")
+  .length;
+
+const submitForm = (form) =>
+  new Promise((res, rej) => {
+    $.ajax({
+      url: $(form).attr("action"),
+      type: "POST",
+      data: $(form).serialize(),
+      success: (data) => res(data),
+      error: (data) => rej(data),
+    })
+  });
+
+const toggle = {
+  "btn-primary": "btn-warning",
+  "btn-warning": "btn-primary"
+};
+
+$("#toggle-checks").on("click", function () {
+  let newClass;
+  Object.keys(toggle).forEach((key) => {
+    if ($(this).hasClass(key)) {
+      newClass = toggle[key];
+    }
+  });
+
+  $(this).removeClass(toggle[newClass]);
+  $(this).addClass(newClass);
+
+  toggleAllCheckboxes(newClass === "btn-warning");
+});

--- a/openipam/report/templates/report/expired_hosts.html
+++ b/openipam/report/templates/report/expired_hosts.html
@@ -2,6 +2,8 @@
 
 {% block page_title %}Expired Hosts Report{% endblock %}
 
+{% load staticfiles %}
+
 {% block extrahead %}
 
 <style type="text/css">
@@ -13,7 +15,6 @@
     margin: 20px;
   }
 </style>
-
 {% endblock %} {% block content %}
 
 <div
@@ -23,51 +24,7 @@
   role="dialog"
   aria-hidden="true"
   style="display: none"
->
-  <div class="modal-dialog">
-    <div class="modal-content">
-      <div class="modal-header">
-        <button
-          type="button"
-          class="close"
-          data-dismiss="modal"
-          aria-hidden="true"
-        >
-          &times;
-        </button>
-        <h3 class="modal-title">
-          <span class="oaction"></span> Confirm Deletion
-        </h3>
-      </div>
-      <div class="modal-body">
-        <div class="clear">
-          <p>
-            Are you sure you want to delete <span id="mac-count">0</span> host(s)?
-          </p>
-          <div class="alert alert-danger" role="alert" id="deletion-error">
-            <span
-              class="glyphicon glyphicon-exclamation-sign"
-              aria-hidden="true"
-            ></span>
-            <span class="sr-only">Error:</span>
-            <div id="deletion-error-message"></div>
-          </div>
-        </div>
-      </div>
-      <div class="modal-footer">
-        <button class="btn btn-danger" id="confirm-delete">Yes</button>
-        <button
-          class="btn btn-default"
-          data-dismiss="modal"
-          aria-hidden="true"
-          id="cancel-delete"
-        >
-          No
-        </button>
-      </div>
-    </div>
-  </div>
-</div>
+> </div>
 
 <div class="content">
   <h1>Expired Hosts</h1>
@@ -76,7 +33,10 @@
     dynamic hosts in the past 2 years or more. In both cases, the hosts must
     also have been seen on the network recently.
   </p>
-
+  <button class="btn btn-primary" id="toggle-checks">
+    <span class="glyphicon glyphicon-check"></span>
+    Toggle All Checkboxes
+  </button>
   <div class="row">
     {% if host_types.static or host_types.dynamic %}
     <div class="col-lg-12">
@@ -85,7 +45,7 @@
 
       <form method="post" action="/api/hosts/bulk_delete/" id="static_hosts" autocomplete="off">
         {% csrf_token %}
-        <button class="btn btn-danger m-b-md" id="delete-static">
+        <button class="btn btn-danger m-b-md">
           <span class="glyphicon glyphicon-trash"></span> Delete Selected
         </button>
         <table class="table table-striped table-condensed table-bordered">
@@ -105,7 +65,6 @@
                   type="checkbox"
                   name="mac_addr[]"
                   value="{{host.mac}}"
-                  checked
                 />
               </td>
               <td>{{ host.hostname }}</td>
@@ -120,7 +79,7 @@
       <h2>Dynamic Hosts - ({{host_types.dynamic|length}})</h2>
       <form method="post" action="/api/hosts/bulk_delete/" id="dynamic_hosts" autocomplete="off">
         {% csrf_token %}
-        <button class="btn btn-danger m-b-md" id="delete-dynamic">
+        <button class="btn btn-danger m-b-md">
           <span class="glyphicon glyphicon-trash"></span> Delete Selected
         </button>
         <table class="table table-striped table-condensed table-bordered">
@@ -140,7 +99,6 @@
                   type="checkbox"
                   name="mac_addr[]"
                   value="{{host.mac}}"
-                  checked
                 />
               </td>
               <td>{{ host.hostname }}</td>
@@ -160,44 +118,25 @@
   </div>
 </div>
 
+<script type="text/javascript" src="{% static 'report/js/host/confirm_modal.js' %}"></script>
+<script type="text/javascript" src="{% static 'report/js/host/multiselect_host_form.js' %}" defer></script>
 <script>
-  const hideError = () => {
-    $("#deletion-error").hide();
-    $("#deletion-error-message").text("");
-    $("#confirm-delete").prop("disabled", false);
-  };
-  $("#delete-static").on("click", hideError);
-  $("#delete-dynamic").on("click", hideError);
-
-  const formSubmit = function (e) {
+  $("#static_hosts").on("submit", function(e) {
     e.preventDefault();
-
-    $("#mac-count").text(
-      $(this)
-        .serializeArray()
-        .filter((input) => input.name === "mac_addr[]").length
+    $("#confirm-modal").confirmHostsModal("Delete Static Hosts", `Are you sure you want to delete ${macCount(this)} static hosts?`,
+      () => submitForm(this),
+      () => window.location.reload(), 
     );
-
-    $("#confirm-modal").modal();
-
-    $("#confirm-delete").on("click", () => {
-      $(this).prop("disabled", true);
-      $.ajax({
-        url: $(this).attr("action"),
-        type: "POST",
-        data: $(this).serialize(),
-        success: () => window.location.reload(),
-        error: (e) => {
-          $("#deletion-error").show();
-          $("#deletion-error-message").text(e.responseJSON);
-        },
-      });
-    });
-
     return false;
-  };
+  });
 
-  $("#static_hosts").on("submit", formSubmit);
-  $("#dynamic_hosts").on("submit", formSubmit);
+  $("#dynamic_hosts").on("submit", function(e) {
+    e.preventDefault();
+    $("#confirm-modal").confirmHostsModal("Delete Dynamic Hosts", `Are you sure you want to delete ${macCount(this)} dynamic hosts?`,
+      () => submitForm(this),
+      () => window.location.reload(), 
+    );
+    return false;
+  });
 </script>
 {% endblock %}

--- a/openipam/report/templates/report/host_dns.html
+++ b/openipam/report/templates/report/host_dns.html
@@ -1,5 +1,11 @@
-{% extends "report/base.html" %} {% block page_title %}Disabled Hosts Report{%
-endblock %} {% block extrahead %} {{ block.super }}
+{% extends "report/base.html" %} 
+{% load staticfiles %}
+{% block page_title %}
+Hosts Missing DNS
+{% endblock %} 
+
+{% block extrahead %}
+{{ block.super }}
 <style type="text/css">
   #content {
     background: #fff;
@@ -14,50 +20,92 @@ endblock %} {% block extrahead %} {{ block.super }}
   });
 </script>
 {% endblock %} {% block content %}
-<h4>Host with no DNS Records</h4>
+<div
+  id="confirm-modal"
+  class="modal fade"
+  tabindex="-1"
+  role="dialog"
+  aria-hidden="true"
+  style="display: none"
+></div>
+
+<h4>Hosts with no DNS Records</h4>
 <p>
-  Hosts that appear not have the required A and/or PTR records or Hosts that
-  just dont have a Foreign Key to DnsRecord.
+  Hosts that appear not have the required A and/or PTR records or that
+  don't have a DnsRecord referencing its' mac address.
 </p>
-<table
-  id="result_list"
-  class="table table-striped table-condensed table-bordered"
->
-  <tr>
-    <thead>
-      <th>Host</th>
-      <th>Mac Address</th>
-      <th>IP Addresses</th>
-      <th>DNS Records</th>
-    </thead>
-  </tr>
-  <tbody>
-    {% if hosts %} {% for host in hosts %}
+<form method="post" action="/api/hosts/bulk_repopulate_dns/" id="dnsless_hosts" autocomplete="off">
+  {% csrf_token %}
+  <button class="btn btn-primary" id="toggle-checks" type="button">
+    <span class="glyphicon glyphicon-check"></span>
+    Toggle All Checkboxes
+  </button>
+  <button class="btn btn-success">
+    <span class="glyphicon glyphicon-tags"></span> Repopulate Selected Hosts' A/PTR Records
+  </button>
+  <br>
+  <br>
+  <table
+    id="result_list"
+    class="table table-striped table-condensed table-bordered"
+  >
     <tr>
-      <td nowrap="nowrap">
-        <a href="{% url 'update_host' pk=host.mac_stripped %}"
-          >{{ host.hostname }}</a
-        >
-      </td>
-      <td>{{ host.mac }}</td>
-      <td>{{ host.ip_addresses|join:", " }}</td>
-      <td>
-        <table class="table table-striped table-condensed table-bordered">
-          {% for record in host.get_dns_records %}
-          <tr>
-            <td>{{ record.name }}</td>
-            <td>{{ record.dns_type }}</td>
-            <td>{{ record.content }}</td>
-          </tr>
-          {% endfor %}
-        </table>
-      </td>
+      <thead>
+        <th>Repopulate</th>
+        <th>Host</th>
+        <th>Mac Address</th>
+        <th>IP Addresses</th>
+        <th>DNS Records</th>
+      </thead>
     </tr>
-    {% endfor %} {% else %}
-    <tr>
-      <td colspan="4" class="warning">No Records... ;)</td>
-    </tr>
-    {% endif %}
-  </tbody>
-</table>
+    <tbody>
+      {% if hosts %} {% for host in hosts %}
+      <tr>
+        <td>
+          <input
+            type="checkbox"
+            name="mac_addr[]"
+            value="{{host.mac}}"
+          />
+        </td>
+        <td nowrap="nowrap">
+          <a href="{% url 'update_host' pk=host.mac_stripped %}"
+            >{{ host.hostname }}</a
+          >
+        </td>
+        <td>{{ host.mac }}</td>
+        <td>{{ host.ip_addresses|join:", " }}</td>
+        <td>
+          <table class="table table-striped table-condensed table-bordered">
+            {% for record in host.get_dns_records %}
+            <tr>
+              <td>{{ record.name }}</td>
+              <td>{{ record.dns_type }}</td>
+              <td>{{ record.content }}</td>
+            </tr>
+            {% endfor %}
+          </table>
+        </td>
+      </tr>
+      {% endfor %} {% else %}
+      <tr>
+        <td colspan="4" class="warning">No Records... ;)</td>
+      </tr>
+      {% endif %}
+    </tbody>
+  </table>
+</form>
+
+<script type="text/javascript" src="{% static 'report/js/host/confirm_modal.js' %}"></script>
+<script type="text/javascript" src="{% static 'report/js/host/multiselect_host_form.js' %}" defer></script>
+<script>
+  $("#dnsless_hosts").on("submit", function(e) {
+    e.preventDefault();
+    $("#confirm-modal").confirmHostsModal("Repopulate DNS Records", `Are you sure you want to attempt to repopulate A/PTR records on ${macCount(this)} static hosts?`,
+      () => submitForm(this),
+      () => window.location.reload(), 
+    );
+    return false;
+  });
+</script>
 {% endblock %}

--- a/openipam/report/templates/report/host_dns.html
+++ b/openipam/report/templates/report/host_dns.html
@@ -31,8 +31,8 @@ Hosts Missing DNS
 
 <h4>Hosts with no DNS Records</h4>
 <p>
-  Hosts that appear not have the required A and/or PTR records or that
-  don't have a DnsRecord referencing its' mac address.
+  Hosts that appear to not have the required A/PTR records, or that
+  don't have a DnsRecord referencing its mac address.
 </p>
 <form method="post" action="/api/hosts/bulk_repopulate_dns/" id="dnsless_hosts" autocomplete="off">
   {% csrf_token %}


### PR DESCRIPTION
Additionally, modularized the confirmation modal and host selection form to use in both expired and dns-less host reports.

Should close #180.