### PR TITLE
Add a skip_related field on /api/hosts to improve query time for queries that don't need related fields

### DIFF
--- a/openipam/api/serializers/hosts.py
+++ b/openipam/api/serializers/hosts.py
@@ -36,6 +36,19 @@ class HostMacSerializer(serializers.ModelSerializer):
         read_only_fields = ("mac",)
 
 
+class HostBasicListSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Host
+        fields = (
+            "mac",
+            "hostname",
+            "expires",
+            "expire_days",
+            "description",
+            "is_dynamic",
+        )
+
+
 class HostListSerializer(serializers.ModelSerializer):
     addresses = serializers.SerializerMethodField()
     attributes = serializers.SerializerMethodField()

--- a/openipam/api/views/hosts.py
+++ b/openipam/api/views/hosts.py
@@ -82,12 +82,19 @@ class HostList(generics.ListAPIView):
     permission_classes = (IsAuthenticated,)
     renderer_classes = (JSONRenderer, BrowsableAPIRenderer, HostCSVRenderer)
     queryset = Host.objects.prefetch_related("addresses", "leases", "pools").all()
-    serializer_class = host_serializers.HostListSerializer
     pagination_class = APIMaxPagination
     filter_backends = (DjangoFilterBackend, filters.OrderingFilter)
     filter_class = HostFilter
     ordering_fields = ("expires", "changed")
     ordering = ("expires",)
+
+    def get_serializer_class(self):
+        # Only spend the time to serialize related fields if get_related is not
+        # "False"
+        do_prefetch = not (self.request.GET.get("get_related", "True") == "False")
+        if do_prefetch:
+            return host_serializers.HostListSerializer
+        return host_serializers.HostBasicListSerializer
 
     # def get_paginate_by(self, queryset=None):
     #     param = self.request.QUERY_PARAMS.get(self.paginate_by_param)

--- a/openipam/api/views/hosts.py
+++ b/openipam/api/views/hosts.py
@@ -90,9 +90,8 @@ class HostList(generics.ListAPIView):
 
     def get_serializer_class(self):
         # Only spend the time to serialize related fields if get_related is not
-        # "False"
-        do_prefetch = not (self.request.GET.get("get_related", "True") == "False")
-        if do_prefetch:
+        # False
+        if not (self.request.GET.get("skip_related", False)):
             return host_serializers.HostListSerializer
         return host_serializers.HostBasicListSerializer
 


### PR DESCRIPTION
NOC only needs hostname and mac address, so we don't need to spend time serializaing addresses and such for those queries - speeding up the overall latency by almost a factor of 2.