### PR TITLE
(wip) Don't allow cname records with names equivalent to existing domains or when other records exist for name

### DIFF
--- a/openipam/dns/models.py
+++ b/openipam/dns/models.py
@@ -407,7 +407,22 @@ class DnsRecord(models.Model):
                     .order_by("-length")
                     .first()
                 )
-                if domain:
+
+                if (
+                    domain
+                    and self.dns_type
+                    and self.dns_type.is_cname_record
+                    and domain.name == self.name
+                ):
+                    raise ValidationError(
+                        {
+                            "name": [
+                                "Cannot create CNAME record with name equivalent to existing domain "
+                                + domain.name
+                            ]
+                        }
+                    )
+                elif domain:
                     self.domain = domain
                 else:
                     raise ValidationError(

--- a/openipam/dns/models.py
+++ b/openipam/dns/models.py
@@ -365,9 +365,7 @@ class DnsRecord(models.Model):
                 )
 
             if self.dns_type.is_cname_record:
-                records = DnsRecord.objects.filter(
-                    name=self.name, dns_type=self.dns_type
-                ).exclude(pk=self.pk)
+                records = DnsRecord.objects.filter(name=self.name).exclude(pk=self.pk)
                 if records:
                     error_list.append(
                         "Trying to create CNAME record while other records exist: %s"


### PR DESCRIPTION
Quick PR to close #106 

On second thought, why shouldn't we allow CNAME records if their name is equivalent to the name of a domain? There are some cases where this may be needed (linux.usu.edu comes to mind as an example).