### PR TITLE
Added dropdowns for expiry thresholds and a record limiter

### DIFF
--- a/openipam/report/templates/report/expired_hosts.html
+++ b/openipam/report/templates/report/expired_hosts.html
@@ -25,6 +25,12 @@
     margin: 20px;
   }
 </style>
+
+<script type="text/javascript">
+	function reloadWithNewThresholds() {
+		window.location.href = '/reports/expired_hosts/?expiry_threshold_static=' + document.getElementById('static-expired').value + '&expiry_threshold_dynamic=' + document.getElementById('dynamic-expired').value + '&limit=' + document.getElementById('limit').value;
+	}
+</script>
 {% endblock %} {% block content %}
 
 <div
@@ -39,9 +45,33 @@
 <div class="content">
   <h1>Expired Hosts</h1>
   <p>
-    Report includes static hosts which expired in the past 5 years or more, and
-    dynamic hosts in the past 2 years or more (Where the mac address has not been seen).
-    In both cases, the hosts must also have been seen on the network recently.
+    Report includes static hosts which expired in the past
+		<select id="static-expired" class="form-control" style="display: inline-block; width: auto;" onchange="reloadWithNewThresholds()">
+			<option value="52" {% if expiry_threshold_static == 52 %}selected{% endif %}>1</option>
+			<option value="104" {% if expiry_threshold_static == 104 %}selected{% endif %}>2</option>
+			<option value="156" {% if expiry_threshold_static == 156 %}selected{% endif %}>3</option>
+			<option value="208" {% if expiry_threshold_static == 208 %}selected{% endif %}>4</option>
+			<option value="260" {% if expiry_threshold_static == 260 %}selected{% endif %}>5</option>
+		</select>
+		years or more, and
+    dynamic hosts in the past
+		<select id="dynamic-expired" class="form-control" style="display: inline-block; width: auto;" onchange="reloadWithNewThresholds()">
+			<option value="52" {% if expiry_threshold_dynamic == 52 %}selected{% endif %}>1</option>
+			<option value="104" {% if expiry_threshold_dynamic == 104 %}selected{% endif %}>2</option>
+			<option value="156" {% if expiry_threshold_dynamic == 156 %}selected{% endif %}>3</option>
+			<option value="208" {% if expiry_threshold_dynamic == 208 %}selected{% endif %}>4</option>
+			<option value="260" {% if expiry_threshold_dynamic == 260 %}selected{% endif %}>5</option>
+		</select>
+		years or more (Where the mac address has not been seen).
+    In both cases, the hosts must also have been seen on the network recently. Fetch
+		<select id="limit" class="form-control" style="display: inline-block; width: auto;" onchange="reloadWithNewThresholds()">
+			<option value="1000" {% if limit == 1000 %}selected{% endif %}>1000</option>
+			<option value="2000" {% if limit == 2000 %}selected{% endif %}>2000</option>
+			<option value="3000" {% if limit == 3000 %}selected{% endif %}>3000</option>
+			<option value="4000" {% if limit == 4000 %}selected{% endif %}>4000</option>
+			<option value="5000" {% if limit == 5000 %}selected{% endif %}>5000</option>
+			<option value="all" {% if limit == 'all' %}selected{% endif %}>All</option>
+		</select> entries.
   </p>
   <button class="btn btn-primary" id="toggle-checks">
     <span class="glyphicon glyphicon-check"></span>

--- a/openipam/report/views.py
+++ b/openipam/report/views.py
@@ -184,13 +184,19 @@ class ExpiredHostsView(GroupRequiredMixin, TemplateView):
     def get_context_data(self, **kwargs):
         context = super(ExpiredHostsView, self).get_context_data(**kwargs)
 
-        expiry_threshold_static = int(self.request.GET.get(
-            "expiry_threshold_static", CONFIG_DEFAULTS["STATIC_HOST_EXPIRY_THRESHOLD_WEEKS"]
-        ))
+        expiry_threshold_static = int(
+            self.request.GET.get(
+                "expiry_threshold_static",
+                CONFIG_DEFAULTS["STATIC_HOST_EXPIRY_THRESHOLD_WEEKS"],
+            )
+        )
 
-        expiry_threshold_dynamic = int(self.request.GET.get(
-            "expiry_threshold_dynamic", CONFIG_DEFAULTS["DYNAMIC_HOST_EXPIRY_THRESHOLD_WEEKS"]
-        ))
+        expiry_threshold_dynamic = int(
+            self.request.GET.get(
+                "expiry_threshold_dynamic",
+                CONFIG_DEFAULTS["DYNAMIC_HOST_EXPIRY_THRESHOLD_WEEKS"],
+            )
+        )
 
         limit = self.request.GET.get("limit", None)
         if limit == "all":
@@ -204,20 +210,14 @@ class ExpiredHostsView(GroupRequiredMixin, TemplateView):
             "static": Host.objects.select_related("mac_history")
             .filter(
                 pools__isnull=False,
-                expires__lte=timezone.now()
-                - timedelta(
-                    weeks=expiry_threshold_static
-                ),
+                expires__lte=timezone.now() - timedelta(weeks=expiry_threshold_static),
                 mac_history__host__isnull=True,
             )
             .order_by("-expires"),
             "dynamic": Host.objects.select_related("mac_history")
             .filter(
                 pools__isnull=True,
-                expires__lte=timezone.now()
-                - timedelta(
-                    weeks=expiry_threshold_dynamic
-                ),
+                expires__lte=timezone.now() - timedelta(weeks=expiry_threshold_dynamic),
                 mac_history__host__isnull=True,
             )
             .order_by("-expires"),


### PR DESCRIPTION
Implemented dropdown selectors for 1-5 year expiry thresholds on the expired hosts report. Updating one will reload the page with the new parameters, as the filtering is done server-side.

My testing showed that, at least on my system with an archive database (and therefore no "last seen" data, which this report uses), reducing the expiry threshold for static hosts to even just 4 years returned over 30,000 entries which locked up my browser for several minutes (long after the server returned its response). So I added a record limiter (which defaults to "all") to help prevent that by only returning 1000, 2000, 3000, 4000, or 5000 records from the server.