### PR TITLE
Expired hosts improvements

### DIFF
--- a/openipam/hosts/management/commands/delete_expired_hosts.py
+++ b/openipam/hosts/management/commands/delete_expired_hosts.py
@@ -1,4 +1,3 @@
-# noqa: D100
 from django.core.management.base import BaseCommand
 from django.utils import timezone
 from datetime import timedelta

--- a/openipam/hosts/management/commands/delete_expired_hosts.py
+++ b/openipam/hosts/management/commands/delete_expired_hosts.py
@@ -1,0 +1,154 @@
+# noqa: D100
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+from datetime import timedelta
+import sys
+
+from openipam.hosts.models import Host, User
+from django.db import transaction
+
+
+class Command(BaseCommand):
+    """Delete hosts which have been expired for a long time."""
+
+    help = "Deletes hosts which have been expired for a long time"
+
+    def add_arguments(self, parser):
+        """Add arguments to the command."""
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help="Do not delete anything, just print what would be deleted.",
+        )
+        parser.add_argument(
+            "--static",
+            action="store_true",
+            dest="static",
+            default=False,
+            help="Delete static hosts.",
+        )
+        parser.add_argument(
+            "--dynamic",
+            action="store_true",
+            dest="dynamic",
+            default=False,
+            help="Delete dynamic hosts.",
+        )
+        parser.add_argument(
+            "--age",
+            action="store",
+            dest="age",
+            type=int,
+            default=None,
+            help="Delete hosts that have been expired for at least this many years.",
+        )
+        parser.add_argument(
+            "user",
+            action="store",
+            type=str,
+            help="Log deletions as this user.",
+        )
+
+    @transaction.atomic
+    def delete(self, hosts, user):
+        """Delete hosts."""
+        print("Deleting %d hosts" % hosts.count())
+        print("Aborting at any time will restore the database to its original state")
+        # Delete hosts by iterating the queryset, so that the delete() method is
+        # called on each host, as this method handles the deletion of indirectly
+        # related objects such as DHCP leases and DNS records.
+        total = hosts.count()
+        isatty = sys.stdout.isatty()
+        i = -1
+        try:
+            for i, host in enumerate(hosts):
+                # Only print progress if we are running in an interactive shell. This is
+                # intended to be run primarily as a cron job, so we do not want to print a lot
+                # of output in that case. Production has a logging plugin for postgresql which
+                # will log the deletions, we don't need to duplicate it in the syslog. For users
+                # though, having some indication that the command is actually running and how
+                # complete it is is useful.
+                if isatty:
+                    print(
+                        f"[ {i / total:6.2%} ] Deleting {str(host)} (expired {host.expires})"
+                    )
+                host.delete(user=user)
+        except KeyboardInterrupt as e:
+            # If we get a keyboard interrupt, it might be beneficial to preserve what changes
+            # were made so far. If we are running in a non-interactive shell, we assume that the
+            # user wants to abort the changes, as this command is primarily intended to be run
+            # automatically. If we are running in an interactive shell, we ask the user if they
+            # want to abort the changes, or preserve them and continue the deletion later.
+            if sys.stdin.isatty():
+                print(
+                    "Keyboard interrupt detected. Would you like to abort the changes?"
+                )
+                print(
+                    "Aborting will restore the database to its original state, no hosts will have been deleted."
+                )
+                if input("Abort changes? [Y/n] ").lower() != "n":
+                    raise e
+
+        # If we are running with interactive input, ask the user if they want to commit the
+        # changes. Otherwise, commit automatically. This is to allow the user to abort the
+        # changes if they are not what they expected. As this command is primarily intended to
+        # be run automatically, we do not want to ask for confirmation in that case.
+        if sys.stdin.isatty():
+            print(f"Changes complete. {i + 1} hosts deleted.")
+            if input("Commit changes? [y/N] ").lower() != "y":
+                raise Exception("Aborted")
+        else:
+            print(f"In total, deleted {i + 1} hosts")
+
+    def handle(self, *args, **options):
+        """Handle the command."""
+        dry_run = options["dry_run"]
+        static = options["static"]
+        dynamic = options["dynamic"]
+        age = options["age"]
+
+        # If age is not specified, default to 5 years if we are
+        # deleting static hosts, 2 years otherwise.
+        if not age:
+            age = 5 if static else 2
+
+        if not static and not dynamic:
+            print("Must specify either --static or --dynamic")
+            sys.exit(2)
+
+        user = User.objects.filter(username=options["user"]).first()
+        if not user:
+            print(f"User {options['user']} does not exist")
+            sys.exit(3)
+
+        if age <= 0:
+            print("Refusing to delete hosts that have not expired yet")
+            sys.exit(4)
+
+        if dry_run:
+            print("Running in dry-run mode. No hosts will be deleted.")
+
+        hosts = (
+            Host.objects.select_related("mac_history")
+            .filter(
+                expires__lte=timezone.now() - timedelta(days=int(365.2422 * age)),
+                mac_history__isnull=True,
+            )
+            .order_by("-expires")
+        )
+        # If we're only deleting one type of host, filter the queryset
+        # to only include that type.
+        if not static or not dynamic:
+            hosts = hosts.filter(
+                # Dynamic hosts have a pool, while static hosts do not.
+                pools__isnull=static,
+            )
+
+        if dry_run:
+            for host in hosts:
+                print(f"Would delete {str(host)} (expired {host.expires})")
+            print(f"In total, {hosts.count()} hosts would be deleted")
+        else:
+            self.delete(hosts, user)

--- a/openipam/report/templates/report/expired_hosts.html
+++ b/openipam/report/templates/report/expired_hosts.html
@@ -27,8 +27,10 @@
 </style>
 
 <script type="text/javascript">
-	function reloadWithNewThresholds() {
-		window.location.href = '/reports/expired_hosts/?expiry_threshold_static=' + document.getElementById('static-expired').value + '&expiry_threshold_dynamic=' + document.getElementById('dynamic-expired').value + '&limit=' + document.getElementById('limit').value;
+ function reloadWithNewThresholds() {
+	 showStatic = document.getElementById('show').value == 'static' || document.getElementById('show').value == 'all';
+	 showDynamic = document.getElementById('show').value == 'dynamic' || document.getElementById('show').value == 'all';
+		window.location.href = '/reports/expired_hosts/?expiry_threshold_static=' + document.getElementById('static-expired').value + '&expiry_threshold_dynamic=' + document.getElementById('dynamic-expired').value + '&limit=' + document.getElementById('limit').value + '&show_static=' + showStatic + '&show_dynamic=' + showDynamic;
 	}
 </script>
 {% endblock %} {% block content %}
@@ -71,7 +73,13 @@
 			<option value="4000" {% if limit == 4000 %}selected{% endif %}>4000</option>
 			<option value="5000" {% if limit == 5000 %}selected{% endif %}>5000</option>
 			<option value="all" {% if limit == 'all' %}selected{% endif %}>All</option>
-		</select> entries.
+		</select> entries. Show <select id="show" class="form-control" style="display: inline-block; width: auto;" onchange="reloadWithNewThresholds()">
+			<option value="all" {% if show == 'all' %}selected{% endif %}>all</option>
+			<option value="static" {% if show == 'static' %}selected{% endif %}>only static</option>
+			<option value="dynamic" {% if show == 'dynamic' %}selected{% endif %}>only dynamic</option>
+			<!-- only show the none option if that is the current state. It's not a useful mode, so don't let the user select it. -->
+			{% if show == 'none' %}<option value="none" selected>none</option>{% endif %}
+		</select> hosts.
   </p>
   <button class="btn btn-primary" id="toggle-checks">
     <span class="glyphicon glyphicon-check"></span>
@@ -80,8 +88,12 @@
   <div class="row">
     {% if host_types.static or host_types.dynamic %}
     <div class="col-lg-12">
-      {% if host_types.static %}
-      <h2>Static Hosts - ({{host_types.static|length}})</h2>
+      {% if host_types.static|length != 0 %}
+			{% if host_counts.static == host_types.static|length %}
+      <h2>Static Hosts - ({{host_counts.static}})</h2>
+			{% else %}
+			<h2>Static Hosts - ({{host_types.static|length}} of {{host_counts.static}})</h2>
+			{% endif %}
 
       <form method="post" action="/api/hosts/bulk_delete/" id="static_hosts" autocomplete="off">
         {% csrf_token %}
@@ -112,8 +124,12 @@
           </tbody>
         </table>
       </form>
-      {% endif %} {% if host_types.dynamic %}
-      <h2>Dynamic Hosts - ({{host_types.dynamic|length}})</h2>
+      {% endif %} {% if host_types.dynamic|length != 0 %}
+			{% if host_counts.dynamic == host_types.dynamic|length %}
+      <h2>Dynamic Hosts - ({{host_counts.dynamic}})</h2>
+			{% else %}
+			<h2>Dynamic Hosts - ({{host_types.dynamic|length}} of {{host_counts.dynamic}})</h2>
+			{% endif %}
       <form method="post" action="/api/hosts/bulk_delete/" id="dynamic_hosts" autocomplete="off">
         {% csrf_token %}
         <table id="dynamic-table" class="table table-striped table-condensed table-bordered">


### PR DESCRIPTION
Multiple improvements to the management of expired hosts:

- **New management command which will delete expired hosts based on how long they have been expired**
  - Default timeframes are the same as the default timeframes in the report (5 years for static, 2 for dynamic)
    - If both static and dynamic hosts are requested, will use the longer default (5 years)
  - When run interactively, prints output for each deleted host and requests confirmation before committing changes at the end
    - This confirmation is not required when run non-interactively (when stdin is not a TTY)
  - Calls each host's delete method individually to ensure things like DNS records and leases and such are cleaned up
  - Includes a dry-run function which will print a description of every host the command would delete, without any database modifications.

- **Fixed expired hosts report listing static hosts under "dynamic" and vice versa**

- **Added dropdown selection to restrict report to show only static or only dynamic (or both)**
  - Currently defaults to only showing static hosts, as there are vastly more dynamic hosts than static hosts, and listing them all can take a long time both on the client and the server

Closes #243.