### PR TITLE
add network filters

### DIFF
--- a/openipam/api/filters/network.py
+++ b/openipam/api/filters/network.py
@@ -4,6 +4,7 @@ from openipam.network.models import Network, Lease
 
 class NetworkFilter(FilterSet):
     network = CharFilter(lookup_expr="net_contains_or_equals")
+    network_in = CharFilter(lookup_expr="net_contained_or_equal")
     name = CharFilter(lookup_expr="icontains")
     dhcp_group = CharFilter(field_name="dhcp_group__name", lookup_expr="icontains")
 

--- a/openipam/api/filters/network.py
+++ b/openipam/api/filters/network.py
@@ -4,7 +4,7 @@ from openipam.network.models import Network, Lease
 
 class NetworkFilter(FilterSet):
     network = CharFilter(lookup_expr="net_contains_or_equals")
-    network_in = CharFilter(lookup_expr="net_contained_or_equal")
+    network_in = CharFilter(lookup_expr="net_contained_or_equal", field_name="network")
     name = CharFilter(lookup_expr="icontains")
     dhcp_group = CharFilter(field_name="dhcp_group__name", lookup_expr="icontains")
 

--- a/openipam/api/serializers/network.py
+++ b/openipam/api/serializers/network.py
@@ -101,14 +101,7 @@ class NetworkListSerializer(serializers.ModelSerializer):
 class NetworkBasicListSerializer(serializers.ModelSerializer):
     class Meta:
         model = Network
-        fields = [
-            "network",
-            "name",
-            "gateway",
-            "description",
-            "dhcp_group",
-            "network_in",
-        ]
+        fields = ["network", "name", "gateway", "description", "dhcp_group"]
 
 
 class NetworkCreateUpdateSerializer(serializers.ModelSerializer):

--- a/openipam/api/serializers/network.py
+++ b/openipam/api/serializers/network.py
@@ -98,6 +98,19 @@ class NetworkListSerializer(serializers.ModelSerializer):
         fields = "__all__"
 
 
+class NetworkBasicListSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Network
+        fields = [
+            "network",
+            "name",
+            "gateway",
+            "description",
+            "dhcp_group",
+            "network_in",
+        ]
+
+
 class NetworkCreateUpdateSerializer(serializers.ModelSerializer):
     network = CidrAddressField()
     gateway = InetAddressField()

--- a/openipam/api/serializers/network.py
+++ b/openipam/api/serializers/network.py
@@ -90,18 +90,24 @@ class NetworkVlanSerializer(serializers.ModelSerializer):
         fields = ["id", "vlan_id", "name", "description"]
 
 
+class UsageSerializer(serializers.Serializer):
+    static_addresses = serializers.IntegerField()
+    dynamic_addresses = serializers.IntegerField()
+    leased_addresses = serializers.IntegerField()
+    expired_addresses = serializers.IntegerField()
+    abandoned_addresses = serializers.IntegerField()
+    unleased_addresses = serializers.IntegerField()
+    reserved_addresses = serializers.IntegerField()
+    available_addresses = serializers.IntegerField()
+
+
 class NetworkListSerializer(serializers.ModelSerializer):
     vlans = NetworkVlanSerializer(many=True, read_only=True)
+    usage = UsageSerializer()
 
     class Meta:
         model = Network
         fields = "__all__"
-
-
-class NetworkBasicListSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Network
-        fields = ["network", "name", "gateway", "description", "dhcp_group"]
 
 
 class NetworkCreateUpdateSerializer(serializers.ModelSerializer):

--- a/openipam/api/views/network.py
+++ b/openipam/api/views/network.py
@@ -314,7 +314,7 @@ class ConvertIPAMNetwork(IPAMNetwork):
 
 class NetworkList(generics.ListAPIView):
     permission_classes = (permissions.IsAuthenticated,)
-    queryset = Network.objects.all().annotate(network_in=F("network"))
+    queryset = Network.objects.all()
     pagination_class = APIPagination
     filter_class = NetworkFilter
 

--- a/openipam/api/views/network.py
+++ b/openipam/api/views/network.py
@@ -316,17 +316,13 @@ class NetworkList(generics.ListAPIView):
     queryset = Network.objects.all()
     pagination_class = APIPagination
     filter_class = NetworkFilter
+    serializer_class = network_serializers.NetworkListSerializer
 
     def filter_queryset(self, queryset):
         try:
             return super(NetworkList, self).filter_queryset(queryset)
         except ValidationError as e:
             raise serializers.ValidationError(e.message)
-
-    def get_serializer_class(self):
-        if not (self.request.GET.get("skip_related", False)):
-            return network_serializers.NetworkListSerializer
-        return network_serializers.NetworkBasicListSerializer
 
 
 class NetworkDetail(generics.RetrieveAPIView):

--- a/openipam/api/views/network.py
+++ b/openipam/api/views/network.py
@@ -1,6 +1,5 @@
 from django.core.exceptions import ValidationError
 from django.db import transaction
-from django.db.models import F
 
 from rest_framework import generics
 from rest_framework import permissions


### PR DESCRIPTION
trying to squeeze as much performance as we can on ipam's side for https://github.com/utahstate/gulv4/issues/15

the required data we need to perform "subnet parsing" can now be queried in ~60ms by filtering parent subnets opposed to ~1.5 sec for essentially the entire network table and its relations.