### PR TITLE
add parent subnet filter to networks and revamped usage data from gul-legacy

### DIFF
--- a/openipam/api/filters/network.py
+++ b/openipam/api/filters/network.py
@@ -4,6 +4,7 @@ from openipam.network.models import Network, Lease
 
 class NetworkFilter(FilterSet):
     network = CharFilter(lookup_expr="net_contains_or_equals")
+    network_in = CharFilter(lookup_expr="net_contained_or_equal", field_name="network")
     name = CharFilter(lookup_expr="icontains")
     dhcp_group = CharFilter(field_name="dhcp_group__name", lookup_expr="icontains")
 

--- a/openipam/api/serializers/network.py
+++ b/openipam/api/serializers/network.py
@@ -90,8 +90,20 @@ class NetworkVlanSerializer(serializers.ModelSerializer):
         fields = ["id", "vlan_id", "name", "description"]
 
 
+class UsageSerializer(serializers.Serializer):
+    static_addresses = serializers.IntegerField()
+    dynamic_addresses = serializers.IntegerField()
+    leased_addresses = serializers.IntegerField()
+    expired_addresses = serializers.IntegerField()
+    abandoned_addresses = serializers.IntegerField()
+    unleased_addresses = serializers.IntegerField()
+    reserved_addresses = serializers.IntegerField()
+    available_addresses = serializers.IntegerField()
+
+
 class NetworkListSerializer(serializers.ModelSerializer):
     vlans = NetworkVlanSerializer(many=True, read_only=True)
+    usage = UsageSerializer()
 
     class Meta:
         model = Network

--- a/openipam/api/views/network.py
+++ b/openipam/api/views/network.py
@@ -315,9 +315,8 @@ class NetworkList(generics.ListAPIView):
     permission_classes = (permissions.IsAuthenticated,)
     queryset = Network.objects.all()
     pagination_class = APIPagination
-    serializer_class = network_serializers.NetworkListSerializer
-    filter_fields = ("network", "name", "dhcp_group__name")
     filter_class = NetworkFilter
+    serializer_class = network_serializers.NetworkListSerializer
 
     def filter_queryset(self, queryset):
         try:

--- a/openipam/network/models.py
+++ b/openipam/network/models.py
@@ -293,9 +293,8 @@ class Network(models.Model):
 
     @property
     def usage(self):
-        count_when = lambda q: Sum(
-            Case(When(q, then=1), default=0, output_field=IntegerField())
-        )
+        def count_when(q):
+            return Sum(Case(When(q, then=1), default=0, output_field=IntegerField()))
 
         return (
             Network.objects.values("network")


### PR DESCRIPTION
moving https://github.com/openipam/django-openipam/pull/277 because my intended scope has changed. 

my initial attempt yesterday at the subnet parser in https://github.com/utahstate/gulv4/pull/32 was to poll the entire dhcp lease table from ipam and cache it. but we're not okay with stale dhcp lease information for noc, and serializing the entire leases table cannot happen every 30 seconds (the noc polling period); so we'd create a ton of backpressure.

instead, we can ask ipam for its networks and related usage data (added here), then append them to nodes' data in the subnet trie. then in a "recursive descent" manner merge the available data to compute address usage information for those subnets.

this used to be the responsibility of gul: https://github.com/utahstate/gul-legacy/blob/master/src/web/subnetparser.py#L225-L274, but with this method we can also pre-compute arp data and attach it in the same manner. it makes much more sense to be here in ipam anyways.