### PR TITLE
Fixes auto-renewed hosts also appearing as "notified and unrenewed"

### DIFF
--- a/openipam/api/views/report.py
+++ b/openipam/api/views/report.py
@@ -11,7 +11,7 @@ from rest_framework.views import APIView
 from rest_framework_csv.renderers import CSVRenderer
 from rest_framework.exceptions import ParseError, ValidationError
 
-from django.db import connection, reset_queries
+from django.db import connection
 from django.db.models.aggregates import Count
 from django.contrib.auth.models import Permission
 from django.apps import apps

--- a/openipam/api/views/report.py
+++ b/openipam/api/views/report.py
@@ -236,6 +236,7 @@ class RenewalStatsView(APIView):
         )
 
         notified = Host.objects.filter(
+            last_notified__isnull=False,
             last_notified__date__gte=start_date,
             last_notified__date__lte=end_date,
         ).difference(auto_renewed_qs)

--- a/openipam/api/views/report.py
+++ b/openipam/api/views/report.py
@@ -1,6 +1,6 @@
 from rest_framework.response import Response
 from rest_framework import status
-from rest_framework.permissions import AllowAny
+from rest_framework.permissions import AllowAny, IsAdminUser
 from rest_framework.renderers import (
     TemplateHTMLRenderer,
     JSONRenderer,
@@ -204,7 +204,7 @@ class ServerHostCSVRenderer(CSVRenderer):
 
 
 class RenewalStatsView(APIView):
-    permission_classes = (AllowAny,)
+    permission_classes = (IsAdminUser,)
     renderer_classes = (BrowsableAPIRenderer, JSONRenderer, CSVRenderer)
 
     def get(self, request, format=None, **kwargs):

--- a/openipam/api/views/report.py
+++ b/openipam/api/views/report.py
@@ -215,12 +215,18 @@ class RenewalStatsView(APIView):
             # TODO: magic number
             start_date = (timezone.now() - timedelta(weeks=1)).date()
         else:
-            start_date = dateutil.parser.parse(start_date).date()
+            try:
+                start_date = dateutil.parser.parse(start_date).date()
+            except ValueError:
+                raise ParseError("'start_date' must be an ISO date string")
 
         if not end_date:
             end_date = timezone.now().date()
         else:
-            end_date = dateutil.parser.parse(end_date).date()
+            try:
+                end_date = dateutil.parser.parse(end_date).date()
+            except ValueError:
+                raise ParseError("'end_date' must be an ISO date string")
 
         # TODO: magic number
         admin_user = User.objects.get(id=1)


### PR DESCRIPTION
The renewal report now excludes any auto-renewed hosts from the subsequent "notifications sent" lists. This could cause display issues for large timescales, though, where having a host show up in both sections may be correct.

This PR also fixes the underlying issue that was causing duplicate entries: auto-renewed hosts were having their `last_notified` fields updated, even though no notifications were being sent. This was being done (via the `update()` queryset method, so without updating the `changed` or `changed_by` fields) after the auto-renewals were applied, meaning that any auto-renewed host would appear in the "notified and unrenewed" list.

From what I can see, this should not impact the notification-sending / auto-renewal logic. The only time the `last_notified` field is referenced in the `by_expiring()` query is to exclude hosts for which a notification had already been sent. It isn't used to include any hosts.